### PR TITLE
Update method indentation for multiple lines

### DIFF
--- a/src/template/snippet.pug
+++ b/src/template/snippet.pug
@@ -1,18 +1,15 @@
 each component, compIndex in components
     | #{component.componentName}(
     if component.props
-        if component.props.length > 1
-            |
-            |
         each prop, propIndex in component.props
-            if component.props.length > 1
-                | #{" ".repeat(4)}
+            if component.props.length > 1 && propIndex !== 0
+                | #{" ".repeat(component.componentName.length + 1)}
             | #{prop.name}: #{prop.type}
-            if propIndex !== (component.props.length -1)
+            if propIndex !== (component.props.length - 1)
                 | ,
                 |
     | )
-    if compIndex !== (components.length -1)
+    if compIndex !== (components.length - 1)
         |
         |
         |

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -21,10 +21,9 @@ You can apply *italic*, **bold**, or \`code\` inline styles.
 3. Arabic numerals
 4. are the only kind supported.",
   "lang": "swift",
-  "snippet": "Button(
-    title: String,
-    kind: Kind,
-    icon: UIImage?)
+  "snippet": "Button(title: String,
+       kind: Kind,
+       icon: UIImage?)
 
 Button()
 
@@ -36,13 +35,12 @@ exports[`Connected Components - Swift Plugin Card.swift snippet creation 1`] = `
 Object {
   "description": "💳 This is not a gambling card! This is a cool, useful tech card!",
   "lang": "swift",
-  "snippet": "Card(
-    title: String,
-    details: String,
-    imageHeader: String?,
-    imageSubHeader: String?,
-    image: UIImage?,
-    imagePosition: ImagePosition,
-    size: Size)",
+  "snippet": "Card(title: String,
+     details: String,
+     imageHeader: String?,
+     imageSubHeader: String?,
+     image: UIImage?,
+     imagePosition: ImagePosition,
+     size: Size)",
 }
 `;


### PR DESCRIPTION
Updated the output method to preferred style for Swift. Here's a comparison:

Previous:
<img width="324" alt="previous" src="https://user-images.githubusercontent.com/7360677/74799502-885ac700-5285-11ea-84ee-badcb72fa899.png">

Current:
<img width="330" alt="Screen Shot 2020-02-18 at 7 30 50 PM" src="https://user-images.githubusercontent.com/7360677/74799509-8c86e480-5285-11ea-8e1d-8ed30c0311f0.png">
